### PR TITLE
Remove extra commas fron JSON theme

### DIFF
--- a/Soda SolarizedDark.sublime-theme
+++ b/Soda SolarizedDark.sublime-theme
@@ -494,7 +494,7 @@
         "layer2.tint": [0, 43, 54],
         "layer0.opacity": 1.0,
         "layer1.opacity": 1.0,
-        "layer2.opacity": 1.0,
+        "layer2.opacity": 1.0
     },
 
 //
@@ -1041,7 +1041,7 @@
         "layer2.tint": [133, 153, 0],
         "layer0.opacity": 1.0,
         "layer1.opacity": 1.0,
-        "layer2.opacity": 1.0,
+        "layer2.opacity": 1.0
     },
 
 //


### PR DESCRIPTION
Removed extra commas from the "Soda SolarizedDark.sublime-theme" file. The syntax errors were generating rendering issues on Sublime 2.
